### PR TITLE
fix: 댓글 등록 시 상태업데이트 관련 수정

### DIFF
--- a/src/components/comment/CommentList.jsx
+++ b/src/components/comment/CommentList.jsx
@@ -19,7 +19,7 @@ const CommentList = ({ postId }) => {
   const postComment = () => {
     if (comment) {
       if (user) {
-        dispatch(__postComment({ postId, comment }));
+        dispatch(__postComment({ postId, comment, userId: user.userId }));
         return setComment('');
       }
       alert('로그인 해주세요.');

--- a/src/components/post/PostSubmit.jsx
+++ b/src/components/post/PostSubmit.jsx
@@ -14,6 +14,7 @@ import {
 } from '../../constants/postOptions';
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getFormattedDate } from '../../utils/dateHandler';
 
 const genOptionByParam = param => {
   return param ? { value: param, label: param } : '';
@@ -23,7 +24,7 @@ const PostSubmit = ({ post, submitApi, pageName }) => {
   const navigation = useNavigate();
   const [division, setDivision] = useState(genOptionByParam(post.division));
   const [onoff, setOnoff] = useState(genOptionByParam(post.onoff));
-  const [startDate, setStartDate] = useState(post?.startDate ?? '');
+  const [startDate, setStartDate] = useState(getFormattedDate(post?.startDate).split(' ')[0] ?? '');
   const [period, setPeriod] = useState(genOptionByParam(post.period));
   const [stack, setStack] = useState(
     post.stack ? post.stack.split(',').map(st => genOptionByParam(st)) : [],

--- a/src/components/post/PostThread.jsx
+++ b/src/components/post/PostThread.jsx
@@ -107,7 +107,9 @@ const PostThread = ({ postId }) => {
               </>
             </PostBasicInfo>
             <PostBasicInfo labelName="모집인원">{post.recruitNum ?? '미정'}</PostBasicInfo>
-            <PostBasicInfo labelName="시작 예정일">{post.startDate ?? '미정'}</PostBasicInfo>
+            <PostBasicInfo labelName="시작 예정일">
+              {getFormattedDate(post.startDate).split(' ')[0] ?? '미정'}
+            </PostBasicInfo>
             <PostBasicInfo labelName="기간">{post.period ?? '미정'}</PostBasicInfo>
           </PostBasicInfoContainer>
           <PostBasicInfoContainer>

--- a/src/redux/modules/CommentSlice.js
+++ b/src/redux/modules/CommentSlice.js
@@ -4,8 +4,9 @@ import commentApi from '../../apis/commentApi';
 export const __postComment = createAsyncThunk('postComment', async (payload, thunkAPI) => {
   try {
     const { postId, comment } = payload;
-    await commentApi.submit(postId, { comment });
-    return thunkAPI.fulfillWithValue(payload);
+    const { data } = await commentApi.submit(postId, { comment });
+    console.log(data);
+    return thunkAPI.fulfillWithValue({ ...payload, commentId: data.commentId });
   } catch (e) {
     return thunkAPI.rejectWithValue(e);
   }

--- a/src/utils/dateHandler.js
+++ b/src/utils/dateHandler.js
@@ -1,4 +1,4 @@
 export const getFormattedDate = date => {
-  const inputDate = date ?? new Date().toString();
+  const inputDate = date ?? new Date().toISOString();
   return inputDate.substring(0, 16).replace('T', ' ');
 };


### PR DESCRIPTION
- 댓글 등록 후 낙관적 업데이트 시 즉시 해당 사용자의 댓글임을 알 수 있도록 하여 상호작용 할 수 있게함.
- 날짜 관련 포맷 처리 수정
